### PR TITLE
Added function to set GPU min and max clocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "nvidia_oc"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvidia_oc"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 license = "MIT"
 description = "A simple command line tool to overclock Nvidia GPUs using the NVML library on Linux. This supports both X11 and Wayland."

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ NVIDIA_OC is a simple Rust CLI tool designed to overclock NVIDIA GPUs on Linux. 
 To set the overclock parameters for your NVIDIA GPU, use the following command:
 
 ```bash
-./nvidia_oc set --index 0 --power-limit 200000 --freq-offset 160 --mem-offset 850
+./nvidia_oc set --index 0 --power-limit 200000 --freq-offset 160 --mem-offset 850 --min-clock 0 --max-clock 2000
 ```
 
 ## Run on Startup
@@ -24,7 +24,7 @@ Description=NVIDIA Overclocking Service
 After=network.target
 
 [Service]
-ExecStart=[path_to_binary]/nvidia_oc set --index 0 --power-limit 200000 --freq-offset 160 --mem-offset 850
+ExecStart=[path_to_binary]/nvidia_oc set --index 0 --power-limit 200000 --freq-offset 160 --mem-offset 850 --min-clock 0 --max-clock 2000
 User=root
 Restart=on-failure
 

--- a/example_config.json
+++ b/example_config.json
@@ -3,7 +3,9 @@
     "0": {
       "freqOffset": 200000,
       "memOffset": 160,
-      "powerLimit": 500
+      "powerLimit": 500,
+      "minClock": 0,
+      "maxClock": 2000
     }
   }
 }


### PR DESCRIPTION
Added the function to set GPU min and max clocks. This funcionality combined with the freq-offset argument allows for effective undervolting of the GPU.

For example if the freq-offset is set to 150 and the max clock is set to the default value then the GPU will run the default clocks at the lower voltage of the freq-offset.

In its current implementation the min-clock and max-clock will only be set successfully if both arguments are provided at the same time.
