### PR TITLE
Add allow_hypen_values for underclocking memory/gfx

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,10 +39,10 @@ enum Commands {
 #[group(required = true, multiple = true)]
 struct Sets {
     /// GPU frequency offset
-    #[arg(short, long)]
+    #[arg(short, long, allow_hyphen_values = true)]
     freq_offset: Option<i32>,
     /// GPU memory frequency offset
-    #[arg(long = "mem-offset")]
+    #[arg(long = "mem-offset", allow_hyphen_values = true)]
     mem_offset: Option<i32>,
     /// GPU power limit in milliwatts
     #[arg(short, long)]


### PR DESCRIPTION
Without this, negative offsets for GPU/memory do not work. Handy for underclocking/optimising clocks for workloads. The underlying type could store the number, but clap would come back with `unexpected argument`


![image](https://github.com/user-attachments/assets/1e7a9f63-b05e-4604-8d80-d37b7058de55)

With the change:
![image](https://github.com/user-attachments/assets/206032b0-c055-4929-94ea-be8db52ea048)

Frequency change verified with nvtop/nvidia-smi
