### PR TITLE
Fix frequency units and NotSupported error for power limit in the get command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ fn main() {
                 let power_limit =
                     get_value(|v| nvml_lib.nvmlDeviceGetEnforcedPowerLimit(raw_device_handle, v));
                 match power_limit {
-                    Ok(power_limit) => println!("GPU power limit: {} mW", power_limit),
+                    Ok(power_limit) => println!("GPU power limit: {} W", power_limit / 1000),
                     Err(e) => eprintln!("Failed to get GPU power limit: {:?}", e),
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ fn main() {
                 }
 
                 let power_limit =
-                    get_value(|v| nvml_lib.nvmlDeviceGetPowerManagementLimit(raw_device_handle, v));
+                    get_value(|v| nvml_lib.nvmlDeviceGetEnforcedPowerLimit(raw_device_handle, v));
                 match power_limit {
                     Ok(power_limit) => println!("GPU power limit: {} mW", power_limit),
                     Err(e) => eprintln!("Failed to get GPU power limit: {:?}", e),

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,15 +141,15 @@ fn main() {
                 let freq_offset =
                     get_value(|v| nvml_lib.nvmlDeviceGetGpcClkVfOffset(raw_device_handle, v));
                 match freq_offset {
-                    Ok(freq_offset) => println!("GPU frequency offset: {} Hz", freq_offset),
-                    Err(e) => eprintln!("Failed to get GPU frequency offset: {:?}", e),
+                    Ok(freq_offset) => println!("GPU core clock offset: {} MHz", freq_offset),
+                    Err(e) => eprintln!("Failed to get GPU core clock offset: {:?}", e),
                 }
 
                 let mem_offset =
                     get_value(|v| nvml_lib.nvmlDeviceGetMemClkVfOffset(raw_device_handle, v));
                 match mem_offset {
-                    Ok(mem_offset) => println!("GPU memory frequency offset: {} Hz", mem_offset),
-                    Err(e) => eprintln!("Failed to get GPU memory frequency offset: {:?}", e),
+                    Ok(mem_offset) => println!("GPU memory clock offset: {} MHz", mem_offset),
+                    Err(e) => eprintln!("Failed to get GPU memory clock offset: {:?}", e),
                 }
 
                 let power_limit =


### PR DESCRIPTION
The nvmlDeviceGetPowerManagementLimit function returns NVML_ERROR_NOT_SUPPORTED for my GPU (RTX 4080 Mobile), I assume this is related to me not being able to set a power limit using nvidia-smi:

```
$ sudo nvidia-smi -pl 175
Changing power management limit is not supported for GPU: 00000000:01:00.0.
Treating as warning and moving on.
All done.
```

The nvmlDeviceGetEnforcedPowerLimit function seems to return the correct power limit, so I replaced it with this. I've also changed the power unit to W from mW for clarity.

And finally, the frequencies were in MHz but the unit shown was Hz, I fixed that too.